### PR TITLE
Generate an index on the plugin names so generating the list of unique n...

### DIFF
--- a/DBHelper.groovy
+++ b/DBHelper.groovy
@@ -23,6 +23,7 @@ class DBHelper {
             db.execute("create table node(instanceid, month, osname, nodenumber)")
             db.execute("create table executor(instanceid, month, numberofexecutors)")
             db.execute("create table importedfile(name)")
+            db.execute("CREATE INDEX plugin_name on plugin (name)")
         }
 
         return db;


### PR DESCRIPTION
This should create the necessary index when creating the database initially, but since the database has already been created the existing stats.db needs to either have the following command run on it manually:

CREATE INDEX plugin_name on plugin (name);

or it should be deleted and allowed to regenerate... that process only took about 20 minutes on my Mac Pro laptop. Either way this will make the select query to get the unique list of plugin names run significantly faster.
