### PR TITLE
Added additional stat types

### DIFF
--- a/createJson.groovy
+++ b/createJson.groovy
@@ -18,6 +18,7 @@ class Generator {
 
     def generateInstallationsJson() {
 
+        println "generating installations.json..."
         def installations = [:]
         db.eachRow("SELECT version, COUNT(*) AS number FROM jenkins WHERE month=(select MAX(month) FROM plugin) GROUP BY version;") {
             installations.put it.version, it.number
@@ -74,6 +75,7 @@ class Generator {
     }
 
     def generateLatestNumbersJson() {
+        println "generating latestNumbers.json..."
         def plugins = [:]
         def latestMonth;
         db.eachRow("SELECT name, COUNT(*) AS number, month FROM plugin WHERE month=(select MAX(month) FROM plugin) AND name NOT LIKE 'privateplugin%' GROUP BY name, month;"){
@@ -88,6 +90,7 @@ class Generator {
 
     // like installations.json, but cumulative descending: number indicates number of installations of given version or higher
     def generateCapabilitiesJson() {
+        println "generating capabilities.json..."
         def installations = [:]
         def higherCap = 0
         db.eachRow("SELECT version, COUNT(*) AS number FROM jenkins WHERE month=(select MAX(month) FROM jenkins) AND version LIKE '1.%' GROUP BY version ORDER BY version DESC;") {


### PR DESCRIPTION
- Added 'capabilities.json' which is basically a reverse cumulative
  'installations.json' to assist plugin developers in choosing base
  versions. Assumptions break down with backported API, but close enough.
- Added 'PLUGIN.versions.json' which contains the most recent month's
  distribution of versions of a specific plugin to assist administrators
  in making update decisions.

Minor changes:
- Ensure installations.json is based on latest month only. When I ran
  the script (no access to the raw stats), the DB contained all months.
  Not sure this is actually needed.
- Changed call order to place the long running process at the end.
