### PR TITLE
Getting rid of rm -rf mongo-data

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,9 @@ node('census && docker') {
 
 
     stage 'Process raw logs'
-    // Nuke and recreate the Mongo data directory.
-    sh "rm -rf mongo-data"
+    // TODO: Fix ownership!
+    // The mongo-data directory will end up containing files and dirs owned by 999:docker that we can't do much about for the moment.
+    // Needs a better fix going forward, but for the moment...
     sh "mkdir -p mongo-data"
     // Make sure the jenkins group can still nuke this directory - it'll get chown'd to the mongod user from the container,
     // but the group isn't changed.


### PR DESCRIPTION
I'd still like to be deleting that directory, but we won't be able to
- it's got a lot of files/dirs that are owned by 999:docker without
group write permissions on them. Sigh.