### PR TITLE
Fix missing stats of Jenkins 2.x

### DIFF
--- a/createJson.groovy
+++ b/createJson.groovy
@@ -160,7 +160,7 @@ class Generator {
         println "generating capabilities.json..."
         def installations = [:]
         def higherCap = 0
-        db.eachRow("SELECT version, COUNT(*) AS number FROM jenkins WHERE month=(select MAX(month) FROM jenkins) AND version LIKE '1.%' GROUP BY version ORDER BY version DESC;") {
+        db.eachRow("SELECT version, COUNT(*) AS number FROM jenkins WHERE month=(select MAX(month) FROM jenkins) AND (version LIKE '1.%' OR version LIKE '2.%') GROUP BY version ORDER BY version DESC;") {
             installations.put it.version, it.number + higherCap
             higherCap += it.number
         }


### PR DESCRIPTION
For [capabilities.json](http://stats.jenkins.io/plugin-installation-trend/capabilities.json): currently it shows `74946` as the total number of Jenkins installs...

@daniel-beck @oleg-nenashev @rtyler @orrc ?