### PR TITLE
Generate JVM version stats per month

### DIFF
--- a/DBHelper.groovy
+++ b/DBHelper.groovy
@@ -12,12 +12,12 @@ class DBHelper {
         // in memory
         // db = groovy.sql.Sql.newInstance("jdbc:sqlite::memory:","org.sqlite.JDBC")
 
-        // persitent
+        // persistent
         def db = groovy.sql.Sql.newInstance("jdbc:sqlite:"+dbFile.absolutePath,"org.sqlite.JDBC")
 
         if(!dbExists){
             // define the tables
-            db.execute("create table jenkins(instanceid, month, version)")
+            db.execute("create table jenkins(instanceid, month, version, jvmvendor, jvmname, jvmversion)")
             db.execute("create table plugin(instanceid, month, name, version)")
             db.execute("create table job(instanceid, month, type, jobnumber)")
             db.execute("create table node(instanceid, month, osname, nodenumber)")

--- a/InstanceJVM.groovy
+++ b/InstanceJVM.groovy
@@ -1,0 +1,5 @@
+class InstanceJVM {
+    String vendor
+    String name
+    String version
+}

--- a/InstanceMetric.groovy
+++ b/InstanceMetric.groovy
@@ -5,8 +5,10 @@ class InstanceMetric {
     String instanceId
     String jenkinsVersion
     String servletContainer
+    InstanceJVM jvm
     def plugins
     def jobTypes
     def nodesOnOs
     int totalExecutors
 }
+

--- a/README.md
+++ b/README.md
@@ -42,21 +42,28 @@ this scipts will create the following files:
 * generate the graphs
    ... you might have to increase the memory: `JAVA_OPTS="-Xmx4000M"`
 
-  `$> groovy generateStats.groovy`
+```
+$> export LANG=en
+$> groovy generateStats.groovy
+```
 
-The final SVGs will be in `[worksapce]/target/svg` 
+
+The final SVGs will be in `[workspace]/target/svg` 
 
 #### JSON (optional)
 
-1. collect the data from the raw json format and store it into a local SQLight database
+1. collect the data from the raw json format and store it into a local SQLite database
    
-    `$> groovy collectNumbers.groovy`
+```
+$> export LANG=en
+$> groovy collectNumbers.groovy`
+```
 
 2. generate the fine grained data set (json) for each plugin
    
     `$> groovy createJson.groovy`
 
-The final json files will be in `[worksapce]/target/stats` - these files have to be uploaded to a webserver to make them available for the confluence plugin.
+The final json files will be in `[workspace]/target/stats` - these files have to be uploaded to a webserver to make them available for the confluence plugin.
 
 
 All the scripts can be reexecuted in case a failure happens, e.g. the download will only download the files he needs and collecting the numbers will only happen on the raw data which is not imported yet.

--- a/collectNumbers.groovy
+++ b/collectNumbers.groovy
@@ -37,7 +37,7 @@ class NumberCollector {
                     System.out.print('.');
                 def instId = metric.instanceId;
 
-                db.execute("insert into jenkins(instanceid, month, version) values( $instId, $monthDate, ${metric.jenkinsVersion})")
+                db.execute("insert into jenkins(instanceid, month, version, jvmvendor, jvmname, jvmversion) values( $instId, $monthDate, ${metric.jenkinsVersion}, ${metric.jvm?.vendor}, ${metric.jvm?.name}, ${metric.jvm?.version})")
 
                 metric.plugins.each { pluginName, pluginVersion ->
                     db.execute("insert into plugin(instanceid, month, name, version) values( $instId, $monthDate, $pluginName, $pluginVersion)")


### PR DESCRIPTION
This change retrieves JVM informations, and for now only generates a
simple count of occurrences per month and JDK Major.Minor version.

Example:

```
{
    "jvmStatsPerMonth": {
        "1228086000000": {
            "1.5": 395,
            "1.6": 129,
            "1.7": 1
        },
        "1230764400000": {
            "1.5": 1544,
            "1.6": 1092,
            "1.7": 5
        },
...
```

Full example (with old dataset): https://gist.github.com/batmat/28361c7cadb0e134fbb8dd1c655190a1

Thanks for review @imod @orrc @daniel-beck @rtyler @oleg-nenashev @abayer 