### PR TITLE
Add stats specific for Jenkins 2+

### DIFF
--- a/createJson.groovy
+++ b/createJson.groovy
@@ -197,8 +197,22 @@ class Generator {
             jvmPerDate.put(month, jvmCount)
         }
 
+        def jvmPerDate2DotxOnly = [:]
+        months.findAll { it > 1459536318000 } // Ignore data before April 2016, when Jenkins 2.0 was released
+              .each    { month ->
+            def jvmCount = [:]
+            db.eachRow("SELECT SUBSTR(jvmversion,1,3) AS jvmv,COUNT(0) AS cnt " +
+                    "FROM jenkins " +
+                    "WHERE month=$month AND $jvmVersionsRestriction AND version like '2.%'" +
+                    "GROUP BY month,jvmv " +
+                    "ORDER BY jvmv;") {
+                jvmCount.put(it.jvmv, it.cnt)
+            }
+            jvmPerDate2DotxOnly.put(month, jvmCount)
+        }
+
         def json = new groovy.json.JsonBuilder()
-        json jvmStatsPerMonth: jvmPerDate
+        json jvmStatsPerMonth: jvmPerDate, jvmStatsPerMonth_2_x: jvmPerDate2DotxOnly
         new File(statsDir, fileName) << groovy.json.JsonOutput.prettyPrint(json.toString())
     }
 


### PR DESCRIPTION
Followup of #21 : Adds a second node which will only show stats for Jenkins 2.x.

I thought that would be interesting, since we're probably likely to ignore anyway very old versions to decide if we switch to JDK/Java 8 baseline. But if the proportion of Java 7 is still high in recent Jenkins versions users, then it might be different.

Ping @imod @rtyler @daniel-beck @abayer  for review, thanks.

Probably to be waited on the fix of https://ci.jenkins.io/job/Infra/job/infra-statistics/job/master/ build before  considering merging.
