### PR TITLE
Don't publish anything when building from a branch or PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,14 +60,19 @@ node('census && docker') {
         sh "groovy generateStats.groovy ${census_dir}/*.json.gz"
     }
 
-    stage 'Publish census'
-    sh "rsync -avz ${census_dir} ${CENSUS_HOST}:/srv/census"
+    if (env.BRANCH_NAME == 'master') {
+        stage 'Publish census'
+        sh "rsync -avz ${census_dir} ${CENSUS_HOST}:/srv/census"
 
-    stage 'Publish stats'
-    try {
-        sh './publish-svgs.sh'
-    }
-    finally {
-        sh 'git checkout master'
+        stage 'Publish stats'
+        try {
+            sh './publish-svgs.sh'
+        }
+        finally {
+            sh 'git checkout master'
+        }
+    } else {
+        stage 'Archive artifacts'
+        archiveArtifacts 'target/svg/*, target/stats/*'
     }
 }


### PR DESCRIPTION
Which seems like a necessary prerequisite before making something a multibranch project.

This should probably be emphasized in any documentation we have.

@rtyler should probably be expedited.