### PR TITLE
Generate HTML tables for plugin/core version distributions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,7 @@ else {
             sh 'mkdir -p target'
             sh "groovy collectNumbers.groovy ${census_dir}/*.json.gz"
             sh 'groovy createJson.groovy'
+            sh 'groovy generateVersionDistribution.groovy'
         }
 
         stage 'Generate stats'
@@ -97,7 +98,7 @@ else {
             }
         } else {
             stage 'Archive artifacts'
-            archiveArtifacts 'target/svg/*, target/stats/*'
+            archiveArtifacts 'target/svg/*, target/stats/*, target/pluginversions/*'
         }
     }
 }

--- a/generateVersionDistribution-template.html
+++ b/generateVersionDistribution-template.html
@@ -32,15 +32,21 @@ $(document).ready(function() {
 
     var coreVersionsSet = new Set();
 
+    var totalInstallsPerPluginVersion = new Map();
+
     var totalInstalls = 0
 
     for (var pluginVersion in versionData) {
         if (/^\d[\d.]*\d$/.test(pluginVersion)) {
-        pluginVersionsSet.add(pluginVersion);
+            pluginVersionsSet.add(pluginVersion);
+            if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
+                totalInstallsPerPluginVersion[pluginVersion] = 0;
+            }
             for (var coreVersion in versionData[pluginVersion]) {
                 if (/^[12][.]\d+(|[.]\d)$/.test(coreVersion)) {
                     coreVersionsSet.add(coreVersion);
                     totalInstalls += versionData[pluginVersion][coreVersion];
+                    totalInstallsPerPluginVersion[pluginVersion] += versionData[pluginVersion][coreVersion];
                 }
             }
         }
@@ -54,15 +60,20 @@ $(document).ready(function() {
     var coreVersions = Array.from(coreVersionsSet);
     coreVersions.sort(collator.compare);
 
+    var thisCoreVersionOrOlderPerPluginVersion = {};
+
     // header row
     var row = $("<tr>");
     row.append($("<th>").html("__NAME__ - " + totalInstalls));
     for (let pluginVersion of pluginVersions) {
         row.append($("<th>").html(pluginVersion));
+        thisCoreVersionOrOlderPerPluginVersion[pluginVersion] = 0;
     }
     row.append($("<th>").html("Sum"));
     row.appendTo('#versionsContainer');
 
+
+    var thisCoreVersionOrOlder = 0
 
     // value rows
     for (let coreVersion of coreVersions) {
@@ -78,9 +89,19 @@ $(document).ready(function() {
                 cnt = 0;
             }
             thisCoreVersion += cnt;
-            row.append($("<td>").attr("title", pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)").css("opacity", (cnt*100/totalInstalls)).html(cnt));
+            var title = pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)";
+            title += " - " + Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
+            row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt));
+
+            thisCoreVersionOrOlderPerPluginVersion[pluginVersion] += cnt;
         }
-        row.append($("<td>").addClass("subtotal").attr("title", coreVersion + " total: " + thisCoreVersion + " installs (" + Math.round(thisCoreVersion/totalInstalls*100) + "%)").html(thisCoreVersion));
+
+        var title = coreVersion + " total: " + thisCoreVersion + " installs (" + Math.round(thisCoreVersion/totalInstalls*100) + "%)";
+        title += " - " + Math.round((1-thisCoreVersionOrOlder/totalInstalls)*100) + "% of plugin installs are on this core version or newer";
+        row.append($("<td>").addClass("subtotal").attr("title", title).html(thisCoreVersion));
+
+        thisCoreVersionOrOlder += thisCoreVersion;
+
         row.appendTo('#versionsContainer');
     }
 });

--- a/generateVersionDistribution-template.html
+++ b/generateVersionDistribution-template.html
@@ -1,0 +1,92 @@
+<html>
+    <head>
+        <title>Plugin and Core Version Matrix for the __NAME__ Plugin</title>
+        <style type="text/css">
+body, table {
+    font-family: monospace;
+}
+table {
+    border-collapse: collapse;
+    border: 1px solid #FF0000;
+}
+
+table td, table th {
+    border: 1px solid #FF0000;
+    text-align: center;
+    padding: 3px;
+}
+tr.lts {
+    background-color: #eef;
+}
+td.subtotal {
+    background-color: #ccc;
+}
+        </style>
+        <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script type="text/javascript">
+$(document).ready(function() {
+
+    var versionData = __DATA__;
+
+    var pluginVersionsSet = new Set();
+
+    var coreVersionsSet = new Set();
+
+    var totalInstalls = 0
+
+    for (var pluginVersion in versionData) {
+        if (/^\d[\d.]*\d$/.test(pluginVersion)) {
+        pluginVersionsSet.add(pluginVersion);
+            for (var coreVersion in versionData[pluginVersion]) {
+                if (/^[12][.]\d+(|[.]\d)$/.test(coreVersion)) {
+                    coreVersionsSet.add(coreVersion);
+                    totalInstalls += versionData[pluginVersion][coreVersion];
+                }
+            }
+        }
+    }
+
+    var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
+
+    var pluginVersions = Array.from(pluginVersionsSet);
+    pluginVersions.sort(collator.compare);
+
+    var coreVersions = Array.from(coreVersionsSet);
+    coreVersions.sort(collator.compare);
+
+    // header row
+    var row = $("<tr>");
+    row.append($("<th>").html("__NAME__ - " + totalInstalls));
+    for (let pluginVersion of pluginVersions) {
+        row.append($("<th>").html(pluginVersion));
+    }
+    row.append($("<th>").html("Sum"));
+    row.appendTo('#versionsContainer');
+
+
+    // value rows
+    for (let coreVersion of coreVersions) {
+        var row = $("<tr>");
+        if (/^\d[.]\d+[.]\d$/.test(coreVersion)) {
+            row.addClass('lts');
+        }
+        row.append($("<th>").html(coreVersion));
+        var thisCoreVersion = 0;
+        for (let pluginVersion of pluginVersions) {
+            var cnt = versionData[pluginVersion][coreVersion];
+            if (cnt == null) {
+                cnt = 0;
+            }
+            thisCoreVersion += cnt;
+            row.append($("<td>").attr("title", pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)").css("opacity", (cnt*100/totalInstalls)).html(cnt));
+        }
+        row.append($("<td>").addClass("subtotal").attr("title", coreVersion + " total: " + thisCoreVersion + " installs (" + Math.round(thisCoreVersion/totalInstalls*100) + "%)").html(thisCoreVersion));
+        row.appendTo('#versionsContainer');
+    }
+});
+        </script>
+    </head>
+    <body>
+        <table id="versionsContainer"></table>
+    </body>
+</html>

--- a/generateVersionDistribution.groovy
+++ b/generateVersionDistribution.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/env groovy
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+
+File file = new File("target/stats", "jenkins-version-per-plugin-version.json")
+
+def json = new JsonSlurper().parseText(file.text)."jenkins-version-per-plugin-version";
+
+json.each { plugin, versions ->
+    File out = new File("target/pluginversions", plugin + ".html")
+    out.parentFile.mkdirs()
+    out.text = new File("generateVersionDistribution-template.html").text.replace("__NAME__", plugin).replace("__DATA__", new JsonBuilder(versions).toString())
+}
+

--- a/publish-svgs.sh
+++ b/publish-svgs.sh
@@ -13,9 +13,11 @@ git config user.email "no-reply@jenkins.io"
 
 cp -R target/svg/* jenkins-stats/svg/
 cp -R target/stats/* plugin-installation-trend/
+cp -R target/pluginversions/* pluginversions/
 
 git add jenkins-stats/svg
 git add plugin-installation-trend
+git add pluginversions
 
 git commit -am "Generating stats" || true
 git push git@github.com:jenkins-infra/infra-statistics.git gh-pages


### PR DESCRIPTION
This generates an HTML file for every plugin for which statistics are available that provides the data from `jenkins-version-per-plugin-version.json` in an easier to understand format -- as a giant table (can always be made easier to digest later…).

I decided to make this a separate script from the others as its input is very limited and at least somewhat well defined (or at least a stable format), it could in theory even be independent from stats generation. This approach allows quicker iteration.