### PR TITLE
Refer to other scripts over https

### DIFF
--- a/jenkins-stats/jenkinsgraph.html
+++ b/jenkins-stats/jenkinsgraph.html
@@ -83,7 +83,7 @@
     
     </script>
 	
-    <script type="text/javascript" src="http://updates.jenkins-ci.org/update-center.json?myparam=true"></script>
+    <script type="text/javascript" src="https://updates.jenkins-ci.org/update-center.json?myparam=true"></script>
 <!--     <script type="text/javascript" src="./test-update-center.json?myparam=true"></script> -->
 </body>
 </html> 


### PR DESCRIPTION
Current FF or Chromium versions are refusing to serve the page as https page is referring to http JS.