### PR TITLE
Better plugin stats

### DIFF
--- a/generateVersionDistribution-template.html
+++ b/generateVersionDistribution-template.html
@@ -2,7 +2,10 @@
     <head>
         <title>Plugin and Core Version Matrix for the __NAME__ Plugin</title>
         <link rel="stylesheet" type="text/css" href="pluginversions.css" />
-        <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script
+          src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+          integrity="sha256-3edrmyuQ0w65f8gfBsqowzjJe2iM6n0nKciPUp8y+7E="
+          crossorigin="anonymous"></script>
         <script type="text/javascript" src="pluginversions.js"></script>
         <script type="text/javascript">
 $(document).ready(function() {

--- a/generateVersionDistribution-template.html
+++ b/generateVersionDistribution-template.html
@@ -1,109 +1,14 @@
 <html>
     <head>
         <title>Plugin and Core Version Matrix for the __NAME__ Plugin</title>
-        <style type="text/css">
-body, table {
-    font-family: monospace;
-}
-table {
-    border-collapse: collapse;
-    border: 1px solid #FF0000;
-}
-
-table td, table th {
-    border: 1px solid #FF0000;
-    text-align: center;
-    padding: 3px;
-}
-tr.lts {
-    background-color: #eef;
-}
-td.subtotal {
-    background-color: #ccc;
-}
-        </style>
+        <link rel="stylesheet" type="text/css" href="pluginversions.css" />
         <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script type="text/javascript" src="pluginversions.js"></script>
         <script type="text/javascript">
 $(document).ready(function() {
-
     var versionData = __DATA__;
 
-    var pluginVersionsSet = new Set();
-
-    var coreVersionsSet = new Set();
-
-    var totalInstallsPerPluginVersion = new Map();
-
-    var totalInstalls = 0
-
-    for (var pluginVersion in versionData) {
-        if (/^\d[\d.]*\d$/.test(pluginVersion)) {
-            pluginVersionsSet.add(pluginVersion);
-            if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
-                totalInstallsPerPluginVersion[pluginVersion] = 0;
-            }
-            for (var coreVersion in versionData[pluginVersion]) {
-                if (/^[12][.]\d+(|[.]\d)$/.test(coreVersion)) {
-                    coreVersionsSet.add(coreVersion);
-                    totalInstalls += versionData[pluginVersion][coreVersion];
-                    totalInstallsPerPluginVersion[pluginVersion] += versionData[pluginVersion][coreVersion];
-                }
-            }
-        }
-    }
-
-    var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
-
-    var pluginVersions = Array.from(pluginVersionsSet);
-    pluginVersions.sort(collator.compare);
-
-    var coreVersions = Array.from(coreVersionsSet);
-    coreVersions.sort(collator.compare);
-
-    var thisCoreVersionOrOlderPerPluginVersion = {};
-
-    // header row
-    var row = $("<tr>");
-    row.append($("<th>").html("__NAME__ - " + totalInstalls));
-    for (let pluginVersion of pluginVersions) {
-        row.append($("<th>").html(pluginVersion));
-        thisCoreVersionOrOlderPerPluginVersion[pluginVersion] = 0;
-    }
-    row.append($("<th>").html("Sum"));
-    row.appendTo('#versionsContainer');
-
-
-    var thisCoreVersionOrOlder = 0
-
-    // value rows
-    for (let coreVersion of coreVersions) {
-        var row = $("<tr>");
-        if (/^\d[.]\d+[.]\d$/.test(coreVersion)) {
-            row.addClass('lts');
-        }
-        row.append($("<th>").html(coreVersion));
-        var thisCoreVersion = 0;
-        for (let pluginVersion of pluginVersions) {
-            var cnt = versionData[pluginVersion][coreVersion];
-            if (cnt == null) {
-                cnt = 0;
-            }
-            thisCoreVersion += cnt;
-            var title = pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)";
-            title += " - " + Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
-            row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt));
-
-            thisCoreVersionOrOlderPerPluginVersion[pluginVersion] += cnt;
-        }
-
-        var title = coreVersion + " total: " + thisCoreVersion + " installs (" + Math.round(thisCoreVersion/totalInstalls*100) + "%)";
-        title += " - " + Math.round((1-thisCoreVersionOrOlder/totalInstalls)*100) + "% of plugin installs are on this core version or newer";
-        row.append($("<td>").addClass("subtotal").attr("title", title).html(thisCoreVersion));
-
-        thisCoreVersionOrOlder += thisCoreVersion;
-
-        row.appendTo('#versionsContainer');
-    }
+    parseData(versionData, "__NAME__");
 });
         </script>
     </head>

--- a/generateVersionDistribution.groovy
+++ b/generateVersionDistribution.groovy
@@ -1,15 +1,29 @@
 #!/usr/bin/env groovy
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+Path indir = Paths.get("pluginversions-static")
+Path outdir = Paths.get("target/pluginversions")
+
+Files.createDirectories(outdir)
+
+Files.list(indir).each { file ->
+    Files.copy(file, outdir.resolve(file.getFileName()), StandardCopyOption.REPLACE_EXISTING)
+}
 
 File file = new File("target/stats", "jenkins-version-per-plugin-version.json")
 
-def json = new JsonSlurper().parseText(file.text)."jenkins-version-per-plugin-version";
+def json = new JsonSlurper().parse(file)."jenkins-version-per-plugin-version";
 
+def htmlTemplate = new File("generateVersionDistribution-template.html").text
 json.each { plugin, versions ->
-    File out = new File("target/pluginversions", plugin + ".html")
-    out.parentFile.mkdirs()
-    out.text = new File("generateVersionDistribution-template.html").text.replace("__NAME__", plugin).replace("__DATA__", new JsonBuilder(versions).toString())
+    File out = new File(outdir.toFile(), plugin + ".html")
+
+    out.text = htmlTemplate.replaceAll("__NAME__", plugin).replace("__DATA__", new JsonBuilder(versions).toString())
 }
 
 "./generate-pluginversions-index.sh target/pluginsversions".execute()

--- a/pluginversions-static/pluginversions.css
+++ b/pluginversions-static/pluginversions.css
@@ -1,0 +1,19 @@
+body, table {
+    font-family: monospace;
+}
+table {
+    border-collapse: collapse;
+    border: 1px solid #FF0000;
+}
+
+table td, table th {
+    border: 1px solid #FF0000;
+    text-align: center;
+    padding: 3px;
+}
+tr.lts {
+    background-color: #eef;
+}
+td.subtotal {
+    background-color: #ccc;
+}

--- a/pluginversions-static/pluginversions.css
+++ b/pluginversions-static/pluginversions.css
@@ -1,19 +1,50 @@
 body, table {
     font-family: monospace;
 }
+
 table {
     border-collapse: collapse;
-    border: 1px solid #FF0000;
+}
+
+thead th, tfoot th, tfoot td {
+    position: sticky;
+    background-color: aquamarine;
+}
+
+thead th {
+    top: 0;
+}
+
+tfoot th, tfoot td {
+    bottom: 0;
 }
 
 table td, table th {
-    border: 1px solid #FF0000;
     text-align: center;
-    padding: 3px;
+    padding: 3px 6px;
+    border: 0;
 }
-tr.lts {
-    background-color: #eef;
+
+tr:nth-child(odd) {
+    background-color: #fff;
 }
-td.subtotal {
+
+tr:nth-child(even) {
+    background-color: #eee;
+}
+
+tr.lts:nth-child(odd) {
     background-color: #ccc;
+}
+
+tr.lts:nth-child(even) {
+    background-color: #bbb;
+}
+
+tr:nth-child(odd) td.subtotal {
+    background-color: #999;
+}
+
+tr:nth-child(even) td.subtotal {
+    background-color: #888;
 }

--- a/pluginversions-static/pluginversions.js
+++ b/pluginversions-static/pluginversions.js
@@ -1,0 +1,79 @@
+
+function parseData(versionData, name) {
+    var pluginVersionsSet = new Set();
+
+    var coreVersionsSet = new Set();
+
+    var totalInstallsPerPluginVersion = new Map();
+
+    var totalInstalls = 0
+
+    for (var pluginVersion in versionData) {
+        if (/^\d[\d.]*\d$/.test(pluginVersion)) {
+            pluginVersionsSet.add(pluginVersion);
+            if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
+                totalInstallsPerPluginVersion[pluginVersion] = 0;
+            }
+            for (var coreVersion in versionData[pluginVersion]) {
+                if (/^[12][.]\d+(|[.]\d)$/.test(coreVersion)) {
+                    coreVersionsSet.add(coreVersion);
+                    totalInstalls += versionData[pluginVersion][coreVersion];
+                    totalInstallsPerPluginVersion[pluginVersion] += versionData[pluginVersion][coreVersion];
+                }
+            }
+        }
+    }
+
+    var collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
+
+    var pluginVersions = Array.from(pluginVersionsSet);
+    pluginVersions.sort(collator.compare);
+
+    var coreVersions = Array.from(coreVersionsSet);
+    coreVersions.sort(collator.compare);
+
+    var thisCoreVersionOrOlderPerPluginVersion = {};
+
+    // header row
+    var row = $("<tr>");
+    row.append($("<th>").html(name + " - " + totalInstalls));
+    for (let pluginVersion of pluginVersions) {
+        row.append($("<th>").html(pluginVersion));
+        thisCoreVersionOrOlderPerPluginVersion[pluginVersion] = 0;
+    }
+    row.append($("<th>").html("Sum"));
+    row.appendTo('#versionsContainer');
+
+
+    var thisCoreVersionOrOlder = 0
+
+    // value rows
+    for (let coreVersion of coreVersions) {
+        var row = $("<tr>");
+        if (/^\d[.]\d+[.]\d$/.test(coreVersion)) {
+            row.addClass('lts');
+        }
+        row.append($("<th>").html(coreVersion));
+        var thisCoreVersion = 0;
+        for (let pluginVersion of pluginVersions) {
+            var cnt = versionData[pluginVersion][coreVersion];
+            if (cnt == null) {
+                cnt = 0;
+            }
+            thisCoreVersion += cnt;
+            var title = pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)";
+            title += " - " + Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
+            row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt));
+
+            thisCoreVersionOrOlderPerPluginVersion[pluginVersion] += cnt;
+        }
+
+        var title = coreVersion + " total: " + thisCoreVersion + " installs (" + Math.round(thisCoreVersion/totalInstalls*100) + "%)";
+        title += " - " + Math.round((1-thisCoreVersionOrOlder/totalInstalls)*100) + "% of plugin installs are on this core version or newer";
+        row.append($("<td>").addClass("subtotal").attr("title", title).html(thisCoreVersion));
+
+        thisCoreVersionOrOlder += thisCoreVersion;
+
+        row.appendTo('#versionsContainer');
+    }
+}

--- a/pluginversions-static/pluginversions.js
+++ b/pluginversions-static/pluginversions.js
@@ -36,16 +36,18 @@ function parseData(versionData, name) {
 
     // header row
     var row = $("<tr>");
-    row.append($("<th>").html(name + " - " + totalInstalls));
+    row.append($("<th>").html(name));
     for (let pluginVersion of pluginVersions) {
         row.append($("<th>").html(pluginVersion));
         thisCoreVersionOrOlderPerPluginVersion[pluginVersion] = 0;
     }
     row.append($("<th>").html("Sum"));
-    row.appendTo('#versionsContainer');
+    var thead = $("<thead>");
+    thead.appendTo('#versionsContainer');
+    row.appendTo(thead);
 
 
-    var thisCoreVersionOrOlder = 0
+    var thisCoreVersionOrOlder = 0;
 
     // value rows
     for (let coreVersion of coreVersions) {
@@ -76,4 +78,16 @@ function parseData(versionData, name) {
 
         row.appendTo('#versionsContainer');
     }
+
+    // footer row
+    var row = $("<tr>");
+    row.append($("<th>").html("Total"));
+    for (let pluginVersion of pluginVersions) {
+        row.append($("<td>").html(totalInstallsPerPluginVersion[pluginVersion]));
+    }
+    row.append($("<td>").html(totalInstalls));
+    var tfoot = $("<tfoot>");
+    tfoot.appendTo('#versionsContainer');
+    row.appendTo(tfoot);
+
 }


### PR DESCRIPTION
I was recently playing around with the design of the plugin stats pages - I wanted to add some more (dynamic) filtering features, but haven't found any round tuits since then ;)

For this reason, so this doesn't get lost:
- Externalize JavaScript and CSS
- Sticky headers and footers (works on [modern browsers](https://caniuse.com/#feat=css-sticky), I also removed borders, since those are fugly with sticky headers and footers)
- Zebra-tables (many shades of grey, better ideas for LTS rows welcome)

Sample: https://jsfiddle.net/k1ey849q/

PS: While trying to "replay" the Jenkinsfile in this repository by hand, I noticed that the docker container `mongo:2` doesn't run on my system, but everything seems to work fine with `mongo:3` (probably related to the [vsyscall change](https://github.com/docker/for-linux/issues/58) in the linux kernel)