### PR TITLE
Ignore zeros

### DIFF
--- a/pluginversions-static/pluginversions.js
+++ b/pluginversions-static/pluginversions.js
@@ -65,7 +65,7 @@ function parseData(versionData, name) {
             thisCoreVersion += cnt;
             var title = pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)";
             title += " - " + Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
-            row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt));
+            row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt > 0 ? cnt: ""));
 
             thisCoreVersionOrOlderPerPluginVersion[pluginVersion] += cnt;
         }

--- a/pluginversions-static/pluginversions.js
+++ b/pluginversions-static/pluginversions.js
@@ -63,8 +63,8 @@ function parseData(versionData, name) {
                 cnt = 0;
             }
             thisCoreVersion += cnt;
-            var title = pluginVersion + " on " + coreVersion + ": " + cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%)";
-            title += " - " + Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
+            var title = pluginVersion + " on " + coreVersion + ": " + (cnt > 0 ? cnt + " installs (" + Math.round(cnt/totalInstalls*100) + "%) - " : "");
+            title += Math.round((1-thisCoreVersionOrOlderPerPluginVersion[pluginVersion]/totalInstallsPerPluginVersion[pluginVersion])*100) + "% of " + pluginVersion + " installs are on this core version or newer";
             row.append($("<td>").attr("title", title).css("opacity", Math.max(0.1, cnt*100/totalInstalls)).html(cnt > 0 ? cnt: ""));
 
             thisCoreVersionOrOlderPerPluginVersion[pluginVersion] += cnt;


### PR DESCRIPTION
This should improve the ability of people to read the table.

Sadly, the table in general is fairly sparse.

It is possible to improve the sparse handling by factoring out single entry rows/columns, but doing that while maintaining the magic percentages requires quite a bit of work, so, for now, baby steps.