### PR TITLE
Fix version for Java 9, and add all existing versions

### DIFF
--- a/createJson.groovy
+++ b/createJson.groovy
@@ -175,7 +175,7 @@ class Generator {
 
     // for each month, counts the number of JVM versions in use (using strict filtering to ignore weird/local JVM version names)
     def generateJvmJson() {
-        final def JVM_VERSIONS = ["1.5", "1.6", "1.7", "1.8", "1.9"]
+        final def JVM_VERSIONS = ["1.5", "1.6", "1.7", "1.8", "9", "10", "11", "12", "13"]
         def jvmVersionsRestriction = "(jvmv='" + JVM_VERSIONS.join("' OR jvmv='") + "')"
         def fileName = 'jvms.json'
         println "generating $fileName..."


### PR DESCRIPTION
Untested, given since last time I worked on this, census data has been locked out. I suppose it's straightforward enough to move on.

@jenkins-infra/java11-support 

cc @daniel-beck @rtyler @abayer who I believe have merge permission here.

Cf. https://openjdk.java.net/jeps/223 to understand the version scheme, and the `1.` removal starting with Java 9.