### PR TITLE
Nicer page titles

### DIFF
--- a/generate-index.sh
+++ b/generate-index.sh
@@ -35,7 +35,7 @@ FILENAME="$DIRNAME/index.html"
 cat > $FILENAME <<EOF
 <html>
   <head>
-    <title>${DIRNAME}</title>
+    <title>Installation Trends JSON</title>
     <style type="text/css">
 * {
   font-family: sans-serif;

--- a/generate-pluginversions-index.sh
+++ b/generate-pluginversions-index.sh
@@ -35,7 +35,7 @@ FILENAME="$DIRNAME/index.html"
 cat > $FILENAME <<EOF
 <html>
   <head>
-    <title>${DIRNAME}</title>
+    <title>Install Counts by Plugin Version and Jenkins Version</title>
     <style type="text/css">
 * {
   font-family: sans-serif;


### PR DESCRIPTION
Currently the page titles have a directory path which is really weird, normally you would repeat the h1...

![image](https://user-images.githubusercontent.com/21194782/60001997-b25cda80-965f-11e9-91c9-d7d420d0817b.png)

@daniel-beck @abayer 