### PR TITLE
Support JEP-229 plugin versions

### DIFF
--- a/pluginversions-static/pluginversions.js
+++ b/pluginversions-static/pluginversions.js
@@ -9,7 +9,7 @@ function parseData(versionData, name) {
     var totalInstalls = 0
 
     for (var pluginVersion in versionData) {
-        if (/^\d[\d.]*\d$/.test(pluginVersion)) {
+        if (/^\d[\w.]*\w$/.test(pluginVersion)) {
             pluginVersionsSet.add(pluginVersion);
             if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
                 totalInstallsPerPluginVersion[pluginVersion] = 0;


### PR DESCRIPTION
Change version RegExp to cover [JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc) versions of plugins while still ignoring `X.Y-SNAPSHOT`. Not sure if that test is needed at all since snapshot filtering seems to be happening when generating the JSON, but this is the safer way to change it.