### PR TITLE
Allow more JEP-229 versions

### DIFF
--- a/pluginversions/pluginversions.js
+++ b/pluginversions/pluginversions.js
@@ -9,7 +9,7 @@ function parseData(versionData, name) {
     var totalInstalls = 0
 
     for (var pluginVersion in versionData) {
-        if (/^\d[\w.]*\w$/.test(pluginVersion)) {
+        if (/^\d[\w.-]*\w$/.test(pluginVersion)) {
             pluginVersionsSet.add(pluginVersion);
             if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
                 totalInstallsPerPluginVersion[pluginVersion] = 0;


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/helpdesk/issues/3815

Extends https://github.com/jenkins-infra/infra-statistics/pull/47 to allow `-`. I think this aligns with Update Center's policy to ignore non-numeric versions (see https://github.com/jenkins-infra/update-center2/pull/673). The goal of filtering public releases only is impossible to achieve by a regex, given that non-public releases only represent tiny fraction of total installs it may not be a concern.