### PR TITLE
Revert "Allow more JEP-229 versions"

### DIFF
--- a/pluginversions/pluginversions.js
+++ b/pluginversions/pluginversions.js
@@ -9,7 +9,7 @@ function parseData(versionData, name) {
     var totalInstalls = 0
 
     for (var pluginVersion in versionData) {
-        if (/^\d[\w.-]*\w$/.test(pluginVersion)) {
+        if (/^\d[\w.]*\w$/.test(pluginVersion)) {
             pluginVersionsSet.add(pluginVersion);
             if (!totalInstallsPerPluginVersion.has(pluginVersion)) {
                 totalInstallsPerPluginVersion[pluginVersion] = 0;


### PR DESCRIPTION
Reverts jenkins-infra/infra-statistics#49

Unintended consequence observed in https://github.com/jenkins-infra/helpdesk/issues/3815#issuecomment-1807277578 

While this change is in the code, it displays many non-public versions for widely used plugins like the git plugin and the git client plugin.  It is easier to change the version string of a new release of the SnakeYAML plugin than to adapt to the noise of many non-public versions being visible in the output.