### PR TITLE
Fix semantic version sorting for plugin versions

### DIFF
--- a/createJson.groovy
+++ b/createJson.groovy
@@ -11,6 +11,14 @@ class Generator {
     def db
     def statsDir
 
+    // Semantic version sorting - pads version components for proper comparison
+    // This ensures versions like "2.10" sort after "2.9" instead of after "2.1"
+    def sortVersion(String version) {
+        version.split('(?=[. -])').collect {
+            it.padLeft(30 - it.length())
+        }.join()
+    }
+
     def Generator(workingDir, db){
         this.db = db
         this.statsDir = new File(workingDir, "stats")
@@ -125,6 +133,10 @@ class Generator {
 				version2number.put it.version, it.number
 				version2percentage[it.version] = (it.number as float)*100/(total[it.month] as float)
 			}
+
+			// Sort versions semantically (by semver) instead of alphanumerically
+			version2number = version2number.sort { a, b -> sortVersion(a.key) <=> sortVersion(b.key) }
+			version2percentage = version2percentage.sort { a, b -> sortVersion(a.key) <=> sortVersion(b.key) }
 			
 			def json = new groovy.json.JsonBuilder()
             json name:name, installations:month2number, installationsPercentage:month2percentage, installationsPerVersion:version2number, installationsPercentagePerVersion:version2percentage


### PR DESCRIPTION
## Description
This PR fixes the issue where `installationsPerVersion` and `installationsPercentagePerVersion` fields in plugin stats JSON files are sorted alphanumerically instead of semantically (by semver).

## Problem
Versions were being sorted as:
```
"2.0", "2.1", "2.10", "2.11", "2.12", "2.3", "2.4", ...
```

Instead of the expected semantic order:
```
"2.0", "2.1", "2.3", "2.4", ..., "2.9", "2.10", "2.11", "2.12"
```

This caused confusing charts on stats.jenkins.io.

## Changes
- Added `sortVersion()` function to `createJson.groovy` that pads version components for proper comparison (matching the existing implementation in `generateStats.groovy`)
- Applied semantic sorting to `version2number` and `version2percentage` maps before JSON serialization in `generatePluginsJson()`

## Testing
The sorting logic is based on the existing `sortVersion()` function in `generateStats.groovy` which is already proven to work correctly.

@smerle33 can you review my code 